### PR TITLE
Prevent crosstalk between apps using this package

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/src/main/kotlin/com/circuskitchens/flutter_datawedge/FlutterDatawedgePlugin.kt
+++ b/android/src/main/kotlin/com/circuskitchens/flutter_datawedge/FlutterDatawedgePlugin.kt
@@ -43,7 +43,7 @@ class FlutterDatawedgePlugin: FlutterPlugin, MethodCallHandler, StreamHandler {
     context = flutterPluginBinding.applicationContext
 
     intentFilter = IntentFilter()
-    intentFilter.addAction(MyIntents.SCAN_EVENT_INTENT_ACTION)
+    intentFilter.addAction(context.packageName + MyIntents.SCAN_EVENT_INTENT_ACTION)
     intentFilter.addAction(DWInterface.ACTION_RESULT)
     intentFilter.addAction(DWInterface.ACTION_RESULT_NOTIFICATION)
     intentFilter.addCategory(Intent.CATEGORY_DEFAULT)
@@ -126,7 +126,7 @@ class FlutterDatawedgePlugin: FlutterPlugin, MethodCallHandler, StreamHandler {
 
     val intentProps = Bundle()
     intentProps.putString("intent_output_enabled", "true")
-    intentProps.putString("intent_action", MyIntents.SCAN_EVENT_INTENT_ACTION)
+    intentProps.putString("intent_action", context.packageName + MyIntents.SCAN_EVENT_INTENT_ACTION)
     intentProps.putString("intent_delivery", profileIntentBroadcast)  //  "2"
     intentConfig.putBundle("PARAM_LIST", intentProps)
     profileConfig.putBundle("PLUGIN_CONFIG", intentConfig)

--- a/android/src/main/kotlin/com/circuskitchens/flutter_datawedge/SinkBroadcastReceiver.kt
+++ b/android/src/main/kotlin/com/circuskitchens/flutter_datawedge/SinkBroadcastReceiver.kt
@@ -24,7 +24,7 @@ class SinkBroadcastReceiver(private var events: EventSink? = null) : BroadcastRe
     }*/
 
     when {
-      action.equals(SCAN_EVENT_INTENT_ACTION) -> {
+      action.equals(context.packageName + SCAN_EVENT_INTENT_ACTION) -> {
         //  A barcode has been scanned
         val source = intent.getStringExtra(DWInterface.DATAWEDGE_SCAN_EXTRA_SOURCE) ?: ""
         val scanData = intent.getStringExtra(DWInterface.DATAWEDGE_SCAN_EXTRA_DATA_STRING) ?: ""

--- a/android/src/main/kotlin/com/circuskitchens/flutter_datawedge/consts/MyIntents.kt
+++ b/android/src/main/kotlin/com/circuskitchens/flutter_datawedge/consts/MyIntents.kt
@@ -2,6 +2,6 @@ package com.circuskitchens.flutter_datawedge.consts
 
 class MyIntents {
   companion object {
-    const val SCAN_EVENT_INTENT_ACTION ="com.circuskitchens.flutter_datawedge.SCAN_EVENT"
+    const val SCAN_EVENT_INTENT_ACTION =".SCAN_EVENT"
   }
 }


### PR DESCRIPTION
- Having the same intent destination for multiple apps on a device (using this package) can lead to weired cross talk (apps in the background receive scan data from other apps): Intent destination is now using the package id from the app using the package
- pubspec.lock should not be checked this into source control for library packages (See [Dart.dev Guides: Libraries - Private Files](https://dart.dev/guides/libraries/private-files#pubspeclock))
- Gradle: jcenter was replaced by mavenCentral

_Btw: It would be nice, if you could enable issues and/or discussions for this repo_